### PR TITLE
fixes for store certification

### DIFF
--- a/Steps/Package.appxmanifest
+++ b/Steps/Package.appxmanifest
@@ -1,43 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
-<Package
-  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
-  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
-  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
-  IgnorableNamespaces="uap mp">
-
-  <Identity
-    Name="NokiaDeveloper.StepsLumiaSensorCoreSDKsampleUWP"
-    Publisher="CN=4AD6DA08-6C39-4A10-98CC-3243374DA59C"
-    Version="2.0.0.0" />
-
-  <mp:PhoneIdentity PhoneProductId="f18c5104-723c-4dbc-8cd6-9f83b83cd162" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
-
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
+  <Identity Name="SensorsQA.Steps-MicrosoftSensorCoreSDKsample" Publisher="CN=71D1DD2A-173B-4256-9750-F6222E68630C" Version="2.0.0.0" />
+  <mp:PhoneIdentity PhoneProductId="f18c5104-723c-4dbc-8cd6-9f83b83cd162" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
-    <DisplayName>Steps - Lumia SensorCore SDK sample</DisplayName>
-    <PublisherDisplayName>Lumia SDK</PublisherDisplayName>
+    <DisplayName>Steps - Microsoft SensorCore SDK sample</DisplayName>
+    <PublisherDisplayName>Sensors QA</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
-
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
   </Dependencies>
-
   <Resources>
-    <Resource Language="x-generate"/>
+    <Resource Language="x-generate" />
   </Resources>
-
   <Applications>
-    <Application Id="App"
-      Executable="$targetnametoken$.exe"
-      EntryPoint="Steps.App">
-      <uap:VisualElements
-        DisplayName="Steps – Lumia SensorCore SDK sample"
-        Square150x150Logo="Assets\steps_launcher150x150.png"
-        Square44x44Logo="Assets\Square44x44Logo.png"
-        Description="Steps"
-        BackgroundColor="#008A00">
-        <uap:DefaultTile Wide310x150Logo="Assets\steps_launcher310x150.png"/>
+    <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="Steps.App">
+      <uap:VisualElements DisplayName="Steps – Lumia SensorCore SDK sample" Square150x150Logo="Assets\steps_launcher150x150.png" Square44x44Logo="Assets\Square44x44Logo.png" Description="Steps" BackgroundColor="#008A00">
+        <uap:DefaultTile Wide310x150Logo="Assets\steps_launcher310x150.png">
+        </uap:DefaultTile>
         <uap:SplashScreen Image="Assets\steps_background_02_620x300.png" />
         <uap:InitialRotationPreference>
           <uap:Rotation Preference="portrait" />
@@ -53,11 +33,10 @@
       </Extensions>
     </Application>
   </Applications>
-
   <Capabilities>
     <Capability Name="internetClientServer" />
-    <DeviceCapability Name="activity" />
     <DeviceCapability Name="location" />
+    <DeviceCapability Name="activity" />
     <DeviceCapability Name="humaninterfacedevice">
       <Device Id="vidpid:0421 0716">
         <Function Type="usage:ffaa 0001" />

--- a/Steps/StepsEngine.cs
+++ b/Steps/StepsEngine.cs
@@ -237,13 +237,7 @@ namespace Steps
         /// <returns>Asynchronous task</returns>
         public static async Task ValidateSettingsAsync()
         {
-            if (!await StepCounter.IsSupportedAsync())
-            {
-                MessageDialog dlg = new MessageDialog(_resourceLoader.GetString("FeatureNotSupported/Message"), _resourceLoader.GetString("FeatureNotSupported/Title"));
-                await dlg.ShowAsync();
-                Application.Current.Exit();
-            }
-            else
+            if (await StepCounter.IsSupportedAsync())
             {
                 // Starting from version 2 of Motion data settings Step counter and Acitivity monitor are always available. In earlier versions system
                 // location setting and Motion data had to be enabled.
@@ -424,7 +418,7 @@ namespace Steps
                 {
                     case SenseError.LocationDisabled:
                         {
-                            dlg = new MessageDialog("Location has been disabled. Do you want to open Location settings now?", "Information");
+                            dlg = new MessageDialog(_resourceLoader.GetString("FeatureDisabled/Location"), _resourceLoader.GetString("FeatureDisabled/Title"));
                             dlg.Commands.Add(new UICommand("Yes", new UICommandInvokedHandler(async (cmd) => await SenseHelper.LaunchLocationSettingsAsync())));
                             dlg.Commands.Add(new UICommand("No", new UICommandInvokedHandler((cmd) => { /* do nothing */ })));
                             await dlg.ShowAsync();
@@ -433,9 +427,15 @@ namespace Steps
                         }
                     case SenseError.SenseDisabled:
                         {
-                            dlg = new MessageDialog("Motion data has been disabled. Do you want to open Motion data settings now?", "Information");
+                            dlg = new MessageDialog(_resourceLoader.GetString("FeatureDisabled/MotionData"), _resourceLoader.GetString("FeatureDisabled/Title"));
                             dlg.Commands.Add(new UICommand("Yes", new UICommandInvokedHandler(async (cmd) => await SenseHelper.LaunchSenseSettingsAsync())));
                             dlg.Commands.Add(new UICommand("No", new UICommandInvokedHandler((cmd) => { /* do nothing */ })));
+                            await dlg.ShowAsync();
+                            return false;
+                        }
+                    case SenseError.SenseNotAvailable:
+                        {
+                            dlg = new MessageDialog(_resourceLoader.GetString("FeatureNotSupported/Message"), _resourceLoader.GetString("FeatureNotSupported/Title"));
                             await dlg.ShowAsync();
                             return false;
                         }

--- a/Steps/Strings/en-US/Resources.resw
+++ b/Steps/Strings/en-US/Resources.resw
@@ -121,7 +121,7 @@
     <value>about</value>
   </data>
   <data name="AboutDescription.Text" xml:space="preserve">
-    <value>The Steps developer sample application demonstrates Lumia SensorCore SDK's Step Counter API functionality.</value>
+    <value>The Steps developer sample application demonstrates the Windows Pedometer API and Lumia SensorCore SDK's Step Counter API functionality.</value>
   </data>
   <data name="AboutDisclaimer.Text" xml:space="preserve">
     <value>This developer sample application has been created to provide tips and best practice guidance for software developers and app designers, and may not have all the features you would expect in a commercial product. This application is published in Store as a free software as it may also have value to regular phone users. The source code and more information of this sample can be from GitHub:</value>
@@ -160,9 +160,7 @@
     <value>Information</value>
   </data>
   <data name="FeatureNotSupported.Message" xml:space="preserve">
-    <value>Sorry, the feature exemplified by this application is not available on your phone.
-
-The application will now exit.</value>
+    <value>Sorry, the features exemplified by this application are not available on your device. This application requires a Windows 10 device that supports either a Pedometer or Lumia SensorCore Motion.</value>
   </data>
   <data name="FeatureNotSupported.Title" xml:space="preserve">
     <value>Lumia SensorCore</value>


### PR DESCRIPTION
On systems that do not support Pedometer or Lumia SensorCore, wait until the main page view is fully loaded before displaying the "Not Supported" information dialog.
